### PR TITLE
Add `disabledIndexes` support to `ActionSheetIOS` for parity w/ `ActionSheetCustom` + clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ https://github.com/alessiocancian/react-native-actionsheet/blob/master/lib/optio
         <td></td>
     </tr>
     <tr>
+        <td>disabledIndexes</td>
+        <td>number[]</td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
         <td>onPress</td>
         <td>function</td>
         <td></td>

--- a/lib/ActionSheetCustom.js
+++ b/lib/ActionSheetCustom.js
@@ -141,14 +141,11 @@ class ActionSheet extends React.Component {
   _createButton (title, index) {
     const styles = getMergedStyles(this.props.styles)
     const { buttonUnderlayColor, cancelButtonIndex, destructiveButtonIndex, disabledIndexes, disabledColor } = this.props
+    const isDisabled = disabledIndexes.indexOf(index) !== -1
     const tintColor = this.props.tintColor || (this._isDarkMode() ? "#4793FF" : "#007AFF")
-    const fontColor = destructiveButtonIndex === index ? WARN_COLOR : tintColor
+    const fontColor = isDisabled ? disabledColor : (destructiveButtonIndex === index ? WARN_COLOR : tintColor)
     const isCancel = cancelButtonIndex === index
     const buttonBoxStyle = isCancel ? styles.cancelButtonBox : styles.buttonBox
-    const isDisabled = disabledIndexes.indexOf(index) !== -1
-    if (isDisabled) {
-      fontColor = disabledColor
-    }
     return (
       <TouchableHighlight
         key={index}

--- a/lib/ActionSheetIOS.js
+++ b/lib/ActionSheetIOS.js
@@ -22,6 +22,11 @@ class ActionSheet extends React.Component {
         options[name] = value
       }
     })
+    const disabledIndexes = options.disabledIndexes
+    if (typeof disabledIndexes !== 'undefined') {
+      options['disabledButtonIndices'] = disabledIndexes
+    }
+    delete options.disabledIndexes
     const callback = options.onPress
     delete options.onPress
     ActionSheetIOS.showActionSheetWithOptions(options, callback)

--- a/lib/options.js
+++ b/lib/options.js
@@ -24,6 +24,12 @@ export default [
   'destructiveButtonIndex',
 
   /**
+   * a list of disabled button indices (optional)
+   * @type int[]
+   */
+  'disabledIndexes',
+
+  /**
    * a title to show above the action sheet
    * @type string
    */

--- a/lib/ts/index.d.ts
+++ b/lib/ts/index.d.ts
@@ -9,6 +9,8 @@ type Props = {
 	tintColor?: string;
 	cancelButtonIndex?: number;
 	destructiveButtonIndex?: number;
+	disabledIndexes?: number[];
+
 	/**
 	 * Only for Android or ActionSheetCustom
 	 */


### PR DESCRIPTION
Exposes and adds type-definition to support `disabledIndexes` which is supported by the underlying RN API (as `disabledButtonIndices`).